### PR TITLE
Fixes for RangeError [ERR_SOCKET_BAD_PORT]

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ this.lookup = (addr, options, done) => {
 
         return socket.on('close', err => {
             if (options.follow > 0) {
-                const match = data.replace(/\r/gm, '').match(/(ReferralServer|Registrar Whois|Whois Server|WHOIS Server|Registrar WHOIS Server):[^\S\n]*((?:r?whois|https?):\/\/)?(.*)/);
+                const match = data.replace(/\r/gm, '').match(/(ReferralServer|Registrar Whois|Whois Server|WHOIS Server|Registrar WHOIS Server):{1,2}[^\S\n]*((?:r?whois|https?):\/\/)?(.*)/);
                 if ((match != null) && (match[3] !== server.host)) {
                     options = _.extend({}, options, {
                             follow: options.follow - 1,
@@ -187,11 +187,15 @@ this.lookup = (addr, options, done) => {
             sockOpts.localAddress = options.bind;
         }
 
-        const socket = net.connect(sockOpts);
-        if (timeout) {
-            socket.setTimeout(timeout);
+        try {
+            const socket = net.connect(sockOpts);
+            if (timeout) {
+                socket.setTimeout(timeout);
+            }
+            return _lookup(socket, done);
+        } catch (conErr) {
+            return done(conErr);
         }
-        return _lookup(socket, done);
     }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "whois-raw",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whois-raw",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "WHOIS client for Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -209,10 +209,34 @@ describe('#lookup()', function() {
     //     })
     // });
 
-    return it('should work with currentzoology.org', done =>
+    it('should work with currentzoology.org', done =>
         whois.lookup('currentzoology.org', function(err, data) {
             assert.ifError(err);
             assert.notEqual(data.toLowerCase().indexOf('currentzoology.org'), -1);
+            return done();
+        })
+    );
+
+    it('should work with clz.do', done =>
+        whois.lookup('clz.do', function(err, data) {
+            assert.ifError(err);
+            assert.notEqual(data.toLowerCase().indexOf('clz.do'), -1);
+            return done();
+        })
+    );
+
+    it('should work with orpheusmusic.com.ng', done =>
+        whois.lookup('orpheusmusic.com.ng', function(err, data) {
+            assert.ifError(err);
+            assert.notEqual(data.toLowerCase().indexOf('orpheusmusic.com.ng'), -1);
+            return done();
+        })
+    );
+
+    it('should work with cityradio.co.bw', done =>
+        whois.lookup('cityradio.co.bw', function(err, data) {
+            assert.ifError(err);
+            assert.notEqual(data.toLowerCase().indexOf('cityradio.co.bw'), -1);
             return done();
         })
     );


### PR DESCRIPTION
Fixes 'RangeError [ERR_SOCKET_BAD_PORT]: Port should be >= 0 and < 65536. Received  whois.nic.do.' uncaught exception caused by regular express issue and uncaught exception when creating a socket.

- In the discovered cases, the lookup data had two ':' characters which resulted in the recursive call to lookup using a server of `: whois.nic.do` instead of `whois.nic.do`.

This thread, https://github.com/FurqanSoftware/node-whois/issues/64, details what people were encountering.  This manifests itself in the whois-parsed module, so that will need to be updated to use this new version.